### PR TITLE
Fixed hand offset rotation configuration loading

### DIFF
--- a/driver_leap/CDriverConfig.cpp
+++ b/driver_leap/CDriverConfig.cpp
@@ -32,7 +32,7 @@ bool CDriverConfig::ms_handsReset = false;
 const std::vector<std::string> g_configAttributes
 {
     "emulatedController", "leftHand", "rightHand", "orientation", "skeleton", "trackingLevel",
-    "desktopOffset", "leftHandOffset", "leftHandOffsetRoation", "rightHandOffset", "rightHandOffsetRoation",
+    "desktopOffset", "leftHandOffset", "leftHandOffsetRotation", "rightHandOffset", "rightHandOffsetRotation",
     "input", "menu", "appMenu", "trigger", "grip",
     "touchpad", "touchpadTouch", "touchpadPress", "touchpadAxes",
     "buttonA", "buttonB", "thumbstick",


### PR DESCRIPTION
Hand offset rotation configurations could not be loaded due to some typos in the attribute names.