### PR TITLE
Added a hotkey for reloading settings.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Controls are changed by game profiles that are enabled automatically when game i
 Available hotkeys in NumLock active state:
 * **Ctrl-P:** Enable/disable right hand controller.
 * **Ctrl-O:** Enable/disable left hand controller.
+* **Ctrl-§:** Reload configuration.
 
 ### HTC Vive controllers emulation
 Game profiles:

--- a/driver_leap/CServerDriver.cpp
+++ b/driver_leap/CServerDriver.cpp
@@ -48,12 +48,13 @@ enum GameCommand : size_t
 
 const std::vector<std::string> g_settingCommands
 {
-    "left_hand", "right_hand"
+    "left_hand", "right_hand", "reload_config"
 };
 enum SettingCommand : size_t
 {
     SC_LeftHand = 0U,
-    SC_RightHand
+    SC_RightHand,
+    SC_ReloadConfig
 };
 
 const char* const CServerDriver::ms_interfaces[]
@@ -288,6 +289,13 @@ void CServerDriver::ProcessExternalMessage(const char *f_message)
                                 bool l_enabled = m_controllers[LCH_Right]->GetEnabled();
                                 m_controllers[LCH_Right]->SetEnabled(!l_enabled);
                                 ProcessLeapControllerPause();
+                            }
+                        } break;
+                        case SC_ReloadConfig:
+                        {
+                            if(m_connectionState)
+                            {
+                                CDriverConfig::LoadConfig();
                             }
                         } break;
                     }

--- a/leap_monitor/CLeapMonitor.cpp
+++ b/leap_monitor/CLeapMonitor.cpp
@@ -97,6 +97,7 @@ CLeapMonitor::CLeapMonitor()
     m_specialHotkey = false;
     m_leftHotkey = false;
     m_rightHotkey = false;
+    m_reloadHotkey = false;
 }
 CLeapMonitor::~CLeapMonitor()
 {
@@ -248,6 +249,20 @@ void CLeapMonitor::Run()
                         {
                             SendCommand("setting right_hand");
                             const std::string l_message("Right hand toggled");
+                            SendNotification(l_message);
+                        }
+                    }
+                }
+
+                l_hotkeyState = ((GetAsyncKeyState(VK_CONTROL) & 0x8000) && (GetAsyncKeyState(0xDC) & 0x8000)); // Ctrl+§
+                {
+                    if(m_reloadHotkey != l_hotkeyState)
+                    {
+                        m_reloadHotkey = l_hotkeyState;
+                        if(m_reloadHotkey)
+                        {
+                            SendCommand("setting reload_config");
+                            const std::string l_message("Configuration reloaded");
                             SendNotification(l_message);
                         }
                     }

--- a/leap_monitor/CLeapMonitor.h
+++ b/leap_monitor/CLeapMonitor.h
@@ -43,6 +43,7 @@ class CLeapMonitor final
     bool m_specialHotkey;
     bool m_leftHotkey;
     bool m_rightHotkey;
+    bool m_reloadHotkey;
 
     CLeapMonitor(const CLeapMonitor &that) = delete;
     CLeapMonitor& operator=(const CLeapMonitor &that) = delete;


### PR DESCRIPTION
Pressing Ctrl+§ now reloads configurations.
This is very useful for adjusting position and rotation offsets.