### PR TITLE
Fixed uninitialised behaviour in LeapGetConnectionInfo.

### DIFF
--- a/driver_leap/Core/CLeapPoller.cpp
+++ b/driver_leap/Core/CLeapPoller.cpp
@@ -123,7 +123,7 @@ void CLeapPoller::Update()
             m_frameLock.unlock();
         }
 
-        LEAP_CONNECTION_INFO l_info;
+        LEAP_CONNECTION_INFO l_info = {sizeof(l_info)};
         if(LeapGetConnectionInfo(m_connection, &l_info) == eLeapRS_Success) m_connected = (l_info.status == eLeapConnectionStatus_Connected);
         else m_connected = false;
     }


### PR DESCRIPTION
You need to initialise the .size field of LEAP_CONNECTION_INFO.
The documentation could do with improving on this front and we're
working on it. In the meantime here's a workaround.