### PR TITLE
Implement support for Controllers to be used as input devices.

### DIFF
--- a/driver_leap/Core/CDriverConfig.cpp
+++ b/driver_leap/Core/CDriverConfig.cpp
@@ -16,7 +16,8 @@ const std::vector<std::string> g_settingNames
     "rootOffsetZ",
     "rootAngleX",
     "rootAngleY",
-    "rootAngleZ"
+    "rootAngleZ",
+    "useControllerInput"
 };
 
 int CDriverConfig::ms_trackingLevel = CDriverConfig::TL_Partial;
@@ -24,6 +25,7 @@ bool CDriverConfig::ms_handsReset = false;
 bool CDriverConfig::ms_useVelocity = false;
 glm::vec3 CDriverConfig::ms_rootOffset = glm::vec3(0.f);
 glm::vec3 CDriverConfig::ms_rootAngle = glm::vec3(0.f);
+bool CDriverConfig::ms_useControllerInput = false;
 
 void CDriverConfig::Load()
 {
@@ -79,6 +81,10 @@ void CDriverConfig::Load()
                         case CS_RootAngleZ:
                             ms_rootAngle.z = glm::clamp(l_attribValue.as_float(0.f), -180.f, 180.f);
                             break;
+
+                        case CS_UseControllerInput:
+                            ms_useControllerInput = l_attribValue.as_bool(false);
+                            break;
                     }
                 }
             }
@@ -109,6 +115,11 @@ const glm::vec3& CDriverConfig::GetRootOffset()
 const glm::vec3& CDriverConfig::GetRootAngle()
 {
     return ms_rootAngle;
+}
+
+bool CDriverConfig::IsControllerInputUsed()
+{
+    return ms_useControllerInput;
 }
 
 void CDriverConfig::ProcessExternalSetting(const char *p_message)
@@ -178,6 +189,13 @@ void CDriverConfig::ProcessExternalSetting(const char *p_message)
                     float l_value = 0.f;
                     if(TryParse(l_chunks[1U], l_value))
                         ms_rootOffset.z = l_value;
+                } break;
+
+                case CS_UseControllerInput:
+                {
+                    int l_value = -1;
+                    if (TryParse(l_chunks[1U], l_value))
+                        ms_useControllerInput = (l_value == 1);
                 } break;
             }
         }

--- a/driver_leap/Core/CDriverConfig.h
+++ b/driver_leap/Core/CDriverConfig.h
@@ -7,6 +7,7 @@ class CDriverConfig final
     static bool ms_useVelocity;
     static glm::vec3 ms_rootOffset;
     static glm::vec3 ms_rootAngle;
+    static bool ms_useControllerInput;
 
     CDriverConfig() = delete;
     ~CDriverConfig() = delete;
@@ -23,7 +24,8 @@ public:
         CS_RootOffsetZ,
         CS_RootAngleX,
         CS_RootAngleY,
-        CS_RootAngleZ
+        CS_RootAngleZ,
+        CS_UseControllerInput
     };
 
     enum TrackingLevel : int
@@ -39,6 +41,7 @@ public:
     static bool IsVelocityUsed();
     static const glm::vec3& GetRootOffset();
     static const glm::vec3& GetRootAngle();
+    static bool IsControllerInputUsed();
 
     static void ProcessExternalSetting(const char *p_message);
 };

--- a/driver_leap/Core/CServerDriver.h
+++ b/driver_leap/Core/CServerDriver.h
@@ -4,6 +4,7 @@ class CLeapPoller;
 class CLeapFrame;
 class CLeapIndexController;
 class CLeapStation;
+class CControllerInput;
 
 class CServerDriver final : public vr::IServerTrackedDeviceProvider
 {
@@ -15,6 +16,7 @@ class CServerDriver final : public vr::IServerTrackedDeviceProvider
     CLeapIndexController *m_leftController;
     CLeapIndexController *m_rightController;
     CLeapStation *m_leapStation;
+    CControllerInput *m_controllerInput;
 
     CServerDriver(const CServerDriver &that) = delete;
     CServerDriver& operator=(const CServerDriver &that) = delete;

--- a/driver_leap/Devices/Controller/CControllerInput.cpp
+++ b/driver_leap/Devices/Controller/CControllerInput.cpp
@@ -1,0 +1,174 @@
+#include "stdafx.h"
+#include "CControllerInput.h"
+#include "JoyShockLibrary.h"
+
+CControllerInput::CControllerInput()
+{
+    m_deviceCount = -1;
+}
+
+CControllerInput::~CControllerInput()
+{
+    JslDisconnectAndDisposeAll();
+}
+
+bool CControllerInput::IsConnected()
+{
+    // NOTE: Joycons work as a pair, so we check if both are still alive, otherwise this check will fail.
+    if ((m_devices[ControllerType::CONTROLLER_JOYCON_LEFT].connected &&
+        m_devices[ControllerType::CONTROLLER_JOYCON_RIGHT].connected) ||
+        m_devices[ControllerType::CONTROLLER_JOYCON_DS4].connected)
+    {
+        return true;
+    }
+
+    m_deviceCount = JslConnectDevices();
+
+    std::vector<int> handles(m_deviceCount);
+    JslGetConnectedDeviceHandles(handles.data(), m_deviceCount);
+
+    for (auto handle : handles)
+    {
+        int type = JslGetControllerType(handle);
+        m_devices[type].connected = true;
+        m_devices[type].handle = handle;
+    }
+
+    // For other controllers, just one of them is enough
+    if (m_devices[ControllerType::CONTROLLER_JOYCON_DS4].connected)
+        return true;
+
+    // For joycons, we need both of them connected
+    return m_devices[ControllerType::CONTROLLER_JOYCON_LEFT].connected && m_devices[ControllerType::CONTROLLER_JOYCON_RIGHT].connected;
+}
+
+void CControllerInput::Update(CLeapIndexController* left, CLeapIndexController* right)
+{
+    if (m_devices[ControllerType::CONTROLLER_JOYCON_LEFT].connected)
+    {
+        JOY_SHOCK_STATE state = JslGetSimpleState(m_devices[ControllerType::CONTROLLER_JOYCON_LEFT].handle);
+
+        // Home
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_SystemTouch, state.buttons & 0x20000);
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_SystemClick, state.buttons & 0x20000);
+
+        // A
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_AClick, state.buttons & 0x00002);
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_ATouch, state.buttons & 0x00002);
+
+        // B
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_BClick, state.buttons & 0x00001);
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_BClick, state.buttons & 0x00001);
+
+        // Joystick XY
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_ThumbstickClick, state.buttons & 0x00040);
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_ThumbstickTouch, state.stickLX > 0 && state.stickLY > 0);
+        left->SetButtonValue(CLeapIndexController::IndexButton::IB_ThumbstickX, state.stickLX);
+        left->SetButtonValue(CLeapIndexController::IndexButton::IB_ThumbstickY, state.stickLY);
+
+        // Trigger
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_TriggerClick, state.buttons & 0x00400);
+        left->SetButtonValue(CLeapIndexController::IndexButton::IB_TriggerValue, state.lTrigger);
+
+        // Grip
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_GripTouch, state.buttons & 0x00100);
+        left->SetButtonValue(CLeapIndexController::IndexButton::IB_GripValue, state.buttons & 0x00100 ? 1.0f : 0.0f);
+        left->SetButtonValue(CLeapIndexController::IndexButton::IB_GripForce, state.buttons & 0x00100 ? 1.0f : 0.0f);
+    }
+
+    if (m_devices[ControllerType::CONTROLLER_JOYCON_RIGHT].connected)
+    {
+        JOY_SHOCK_STATE state = JslGetSimpleState(m_devices[ControllerType::CONTROLLER_JOYCON_RIGHT].handle);
+
+        // Home
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_SystemTouch, state.buttons & 0x10000);
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_SystemClick, state.buttons & 0x10000);
+
+        // A
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_AClick, state.buttons & 0x01000);
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_AClick, state.buttons & 0x01000);
+
+        // B
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_BClick, state.buttons & 0x08000);
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_BClick, state.buttons & 0x08000);
+
+        // Joystick XY
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_ThumbstickClick, state.buttons & 0x00080);
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_ThumbstickTouch, state.stickRX > 0 && state.stickRY > 0);
+        right->SetButtonValue(CLeapIndexController::IndexButton::IB_ThumbstickX, state.stickRX);
+        right->SetButtonValue(CLeapIndexController::IndexButton::IB_ThumbstickY, state.stickRY);
+
+        // Trigger
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_TriggerClick, state.buttons & 0x00800);
+        right->SetButtonValue(CLeapIndexController::IndexButton::IB_TriggerValue, state.rTrigger);
+
+        // Grip
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_GripTouch, state.buttons & 0x00200);
+        right->SetButtonValue(CLeapIndexController::IndexButton::IB_GripValue, state.buttons & 0x00200 ? 1.0f : 0.0f);
+        right->SetButtonValue(CLeapIndexController::IndexButton::IB_GripForce, state.buttons & 0x00200 ? 1.0f : 0.0f);
+    }
+
+    if (m_devices[ControllerType::CONTROLLER_JOYCON_DS4].connected)
+    {
+        JOY_SHOCK_STATE state = JslGetSimpleState(m_devices[ControllerType::CONTROLLER_JOYCON_DS4].handle);
+
+        // Home
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_SystemTouch, state.buttons & 0x10000);
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_SystemClick, state.buttons & 0x10000);
+
+        // A
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_AClick, state.buttons & 0x00002);
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_ATouch, state.buttons & 0x00002);
+
+        // B
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_BClick, state.buttons & 0x00001);
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_BClick, state.buttons & 0x00001);
+
+        // Joystick XY
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_ThumbstickClick, state.buttons & 0x00040);
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_ThumbstickTouch, state.stickLX > 0 && state.stickLY > 0);
+        left->SetButtonValue(CLeapIndexController::IndexButton::IB_ThumbstickX, state.stickLX);
+        left->SetButtonValue(CLeapIndexController::IndexButton::IB_ThumbstickY, state.stickLY);
+
+        // Trigger
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_TriggerClick, state.buttons & 0x00400);
+        left->SetButtonValue(CLeapIndexController::IndexButton::IB_TriggerValue, state.lTrigger);
+
+        // Grip
+        left->SetButtonState(CLeapIndexController::IndexButton::IB_GripTouch, state.buttons & 0x00100);
+        left->SetButtonValue(CLeapIndexController::IndexButton::IB_GripValue, state.buttons & 0x00100 ? 1.0f : 0.0f);
+        left->SetButtonValue(CLeapIndexController::IndexButton::IB_GripForce, state.buttons & 0x00100 ? 1.0f : 0.0f);
+
+        // Home
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_SystemTouch, state.buttons & 0x10000);
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_SystemClick, state.buttons & 0x10000);
+
+        // A
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_AClick, state.buttons & 0x01000);
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_AClick, state.buttons & 0x01000);
+
+        // B
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_BClick, state.buttons & 0x08000);
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_BClick, state.buttons & 0x08000);
+
+        // Joystick XY
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_ThumbstickClick, state.buttons & 0x00080);
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_ThumbstickTouch, state.stickRX > 0 && state.stickRY > 0);
+        right->SetButtonValue(CLeapIndexController::IndexButton::IB_ThumbstickX, state.stickRX);
+        right->SetButtonValue(CLeapIndexController::IndexButton::IB_ThumbstickY, state.stickRY);
+
+        // Trigger
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_TriggerClick, state.buttons & 0x00800);
+        right->SetButtonValue(CLeapIndexController::IndexButton::IB_TriggerValue, state.rTrigger);
+
+        // Grip
+        right->SetButtonState(CLeapIndexController::IndexButton::IB_GripTouch, state.buttons & 0x00200);
+        right->SetButtonValue(CLeapIndexController::IndexButton::IB_GripValue, state.buttons & 0x00200 ? 1.0f : 0.0f);
+        right->SetButtonValue(CLeapIndexController::IndexButton::IB_GripForce, state.buttons & 0x00200 ? 1.0f : 0.0f);
+    }
+
+    for (size_t i = 0U; i < m_devices.size(); i++)
+    {
+        m_devices[i].connected = JslStillConnected(m_devices[i].handle);
+    }
+}

--- a/driver_leap/Devices/Controller/CControllerInput.h
+++ b/driver_leap/Devices/Controller/CControllerInput.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <stdint.h>
+#include <map>
+
+#include "Devices/Controller/CLeapIndexController.h"
+
+// NOTE: these are directly mapped to JoyShockLibrary types (refer: https://github.com/JibbSmart/JoyShockLibrary/blob/master/JoyShockLibrary/JoyShockLibrary.h)
+enum ControllerType : uint8_t {
+	CONTROLLER_JOYCON_LEFT = 1,
+	CONTROLLER_JOYCON_RIGHT = 2,
+	CONTROLLER_JOYCON_DS4 = 4
+};
+
+class CControllerInput {
+	struct Device {
+		bool connected{ false };
+		int handle{ -1 };
+	};
+
+	int32_t m_deviceCount;
+	std::map<uint8_t, Device> m_devices;
+public:
+	explicit CControllerInput();
+	~CControllerInput();
+
+	bool IsConnected();
+	void Update(CLeapIndexController* left, CLeapIndexController* right);
+};

--- a/driver_leap/Devices/Controller/CLeapIndexController.cpp
+++ b/driver_leap/Devices/Controller/CLeapIndexController.cpp
@@ -412,17 +412,20 @@ void CLeapIndexController::UpdatePose(const CLeapHand *p_hand)
 
 void CLeapIndexController::UpdateInput(const CLeapHand *p_hand)
 {
-    float l_trigger = p_hand->GetFingerBend(CLeapHand::Finger::Index);
-    m_buttons[IB_TriggerValue]->SetValue(l_trigger);
-    m_buttons[IB_TriggerTouch]->SetState(l_trigger >= 0.5f);
-    m_buttons[IB_TriggerClick]->SetState(l_trigger >= 0.75f);
+    if (!CDriverConfig::IsControllerInputUsed())
+    {
+        float l_trigger = p_hand->GetFingerBend(CLeapHand::Finger::Index);
+        m_buttons[IB_TriggerValue]->SetValue(l_trigger);
+        m_buttons[IB_TriggerTouch]->SetState(l_trigger >= 0.5f);
+        m_buttons[IB_TriggerClick]->SetState(l_trigger >= 0.75f);
 
-    float l_grabValue = p_hand->GetGrabValue();
-    m_buttons[IB_GripValue]->SetValue(l_grabValue);
-    m_buttons[IB_GripTouch]->SetState(l_grabValue >= 0.75f);
-    m_buttons[IB_GripForce]->SetValue((l_grabValue >= 0.9f) ? (l_grabValue - 0.9f) * 10.f : 0.f);
+        float l_grabValue = p_hand->GetGrabValue();
+        m_buttons[IB_GripValue]->SetValue(l_grabValue);
+        m_buttons[IB_GripTouch]->SetState(l_grabValue >= 0.75f);
+        m_buttons[IB_GripForce]->SetValue((l_grabValue >= 0.9f) ? (l_grabValue - 0.9f) * 10.f : 0.f);
+    }
 
-    m_buttons[IB_FingerIndex]->SetValue(l_trigger);
+    m_buttons[IB_FingerIndex]->SetValue(p_hand->GetFingerBend(CLeapHand::Finger::Index));
     m_buttons[IB_FingerMiddle]->SetValue(p_hand->GetFingerBend(CLeapHand::Finger::Middle));
     m_buttons[IB_FingerRing]->SetValue(p_hand->GetFingerBend(CLeapHand::Finger::Ring));
     m_buttons[IB_FingerPinky]->SetValue(p_hand->GetFingerBend(CLeapHand::Finger::Pinky));

--- a/driver_leap/driver_leap.vcxproj
+++ b/driver_leap/driver_leap.vcxproj
@@ -88,15 +88,15 @@
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
-      <AdditionalIncludeDirectories>./;../vendor/LeapSDK/include;../vendor/openvr/headers;../vendor/pugixml/src;../vendor/glm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>./;../vendor/LeapSDK/include;../vendor/openvr/headers;../vendor/pugixml/src;../vendor/glm;../vendor/JSL;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
-      <AdditionalLibraryDirectories>../vendor/LeapSDK/lib/x64;../vendor/openvr/lib/win64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>openvr_api.lib;LeapC.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>../vendor/LeapSDK/lib/x64;../vendor/openvr/lib/win64;../vendor/JSL/x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>openvr_api.lib;LeapC.lib;JoyShockLibrary.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <CustomBuildStep>
@@ -111,7 +111,7 @@
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
-      <AdditionalIncludeDirectories>./;../vendor/LeapSDK/include;../vendor/openvr/headers;../vendor/pugixml/src;../vendor/glm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>./;../vendor/LeapSDK/include;../vendor/openvr/headers;../vendor/pugixml/src;../vendor/glm;../vendor/JSL;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <SDLCheck>true</SDLCheck>
     </ClCompile>
@@ -119,8 +119,8 @@
       <SubSystem>Windows</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
-      <AdditionalLibraryDirectories>../vendor/LeapSDK/lib/x64;../vendor/openvr/lib/win64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>openvr_api.lib;LeapC.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>../vendor/LeapSDK/lib/x64;../vendor/openvr/lib/win64;../vendor/JSL/x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>openvr_api.lib;LeapC.lib;JoyShockLibrary.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>false</GenerateDebugInformation>
     </Link>
     <CustomBuildStep>
@@ -136,6 +136,7 @@
     <ClInclude Include="Core\CServerDriver.h" />
     <ClInclude Include="Devices\CLeapStation.h" />
     <ClInclude Include="Devices\Controller\CControllerButton.h" />
+    <ClInclude Include="Devices\Controller\CControllerInput.h" />
     <ClInclude Include="Devices\Controller\CLeapIndexController.h" />
     <ClInclude Include="Leap\CLeapFrame.h" />
     <ClInclude Include="Leap\CLeapHand.h" />
@@ -152,6 +153,7 @@
     <ClCompile Include="Core\CServerDriver.cpp" />
     <ClCompile Include="Devices\CLeapStation.cpp" />
     <ClCompile Include="Devices\Controller\CControllerButton.cpp" />
+    <ClCompile Include="Devices\Controller\CControllerInput.cpp" />
     <ClCompile Include="Devices\Controller\CLeapIndexController.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="Leap\CLeapFrame.cpp" />

--- a/driver_leap/driver_leap.vcxproj.filters
+++ b/driver_leap/driver_leap.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="Devices\Controller\CLeapIndexController.cpp">
       <Filter>Devices\Controller</Filter>
     </ClCompile>
+    <ClCompile Include="Devices\Controller\CControllerInput.cpp">
+      <Filter>Devices\Controller</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
@@ -61,6 +64,9 @@
       <Filter>Devices\Controller</Filter>
     </ClInclude>
     <ClInclude Include="Devices\Controller\CLeapIndexController.h">
+      <Filter>Devices\Controller</Filter>
+    </ClInclude>
+    <ClInclude Include="Devices\Controller\CControllerInput.h">
       <Filter>Devices\Controller</Filter>
     </ClInclude>
   </ItemGroup>

--- a/leap_control/Managers/CSettingsManager.cpp
+++ b/leap_control/Managers/CSettingsManager.cpp
@@ -21,7 +21,8 @@ const std::vector<std::string> g_settingNames
     "overlayAngleY",
     "overlayAngleZ",
     "startMinimized",
-    "overlaySize"
+    "overlaySize",
+    "useControllerInput"
 };
 
 CSettingsManager* CSettingsManager::ms_instance = nullptr;
@@ -38,6 +39,7 @@ CSettingsManager::CSettingsManager()
     m_overlayAngle = glm::vec3(0.f);
     m_startMinimized = false;
     m_overlaySize = 0.128f;
+    m_useControllerInput = false;
 }
 
 CSettingsManager* CSettingsManager::GetInstance()
@@ -138,6 +140,10 @@ void CSettingsManager::Load()
                         case ST_OverlaySize:
                             m_overlaySize = glm::clamp(l_attribValue.as_float(0.128f), 0.1f, 0.5f);
                             break;
+
+                        case ST_UseControllerInput:
+                            m_useControllerInput = l_attribValue.as_bool(false);
+                            break;
                     }
                 }
             }
@@ -232,6 +238,10 @@ void CSettingsManager::Save()
             case ST_OverlaySize:
                 l_valueAttrib.set_value(m_overlaySize);
                 break;
+
+            case ST_UseControllerInput:
+                l_valueAttrib.set_value(m_useControllerInput);
+                break;
         }
     }
 
@@ -288,6 +298,11 @@ float CSettingsManager::GetOverlaySize() const
     return m_overlaySize;
 }
 
+bool CSettingsManager::GetUseControllerInput() const
+{
+    return m_useControllerInput;
+}
+
 void CSettingsManager::SetSetting(SettingType p_setting, int p_value)
 {
     switch(p_setting)
@@ -315,6 +330,10 @@ void CSettingsManager::SetSetting(SettingType p_setting, bool p_value)
 
         case ST_StartMinimized:
             m_startMinimized = p_value;
+            break;
+
+        case ST_UseControllerInput:
+            m_useControllerInput = p_value;
             break;
     }
 }

--- a/leap_control/Managers/CSettingsManager.h
+++ b/leap_control/Managers/CSettingsManager.h
@@ -14,6 +14,7 @@ class CSettingsManager
     glm::vec3 m_overlayAngle;
     bool m_startMinimized;
     float m_overlaySize;
+    bool m_useControllerInput;
 
     CSettingsManager();
     CSettingsManager(const CSettingsManager &that) = delete;
@@ -40,6 +41,7 @@ public:
         ST_OverlayAngleZ,
         ST_StartMinimized,
         ST_OverlaySize,
+        ST_UseControllerInput,
 
         Count
     };
@@ -59,6 +61,7 @@ public:
     const glm::vec3& GetOverlayOffset() const;
     const glm::vec3& GetOverlayAngle() const;
     float GetOverlaySize() const;
+    bool GetUseControllerInput() const;
 
     void SetSetting(SettingType p_setting, int p_value);
     void SetSetting(SettingType p_setting, bool p_value);

--- a/leap_control/Ui/leap_control.cpp
+++ b/leap_control/Ui/leap_control.cpp
@@ -19,6 +19,9 @@ leap_control::leap_control(QWidget *parent) : QWidget(parent)
     ui.m_useVelocityCheckBox->setChecked(CSettingsManager::GetInstance()->GetUseVelocity());
     connect(ui.m_useVelocityCheckBox, &QCheckBox::stateChanged, this, &leap_control::OnUseVelocityChange);
 
+    ui.m_useControllerInputCheckBox->setChecked(CSettingsManager::GetInstance()->GetUseControllerInput());
+    connect(ui.m_useControllerInputCheckBox, &QCheckBox::stateChanged, this, &leap_control::OnUseControllerInputChange);
+
     ui.m_startMinimizedCheckBox->setChecked(CSettingsManager::GetInstance()->GetStartMinimized());
     connect(ui.m_startMinimizedCheckBox, &QCheckBox::stateChanged, this, &leap_control::OnStartMinimizedChanged);
 
@@ -112,6 +115,17 @@ void leap_control::OnUseVelocityChange(int p_state)
         CSettingsManager::GetInstance()->SetSetting(CSettingsManager::ST_UseVelocity, (p_state == Qt::Checked));
 
         std::string l_message("useVelocity ");
+        l_message.append(std::to_string((p_state == Qt::Checked) ? 1 : 0));
+        CVRManager::GetInstance()->SendStationMessage(l_message);
+    }
+}
+void leap_control::OnUseControllerInputChange(int p_state)
+{
+    if (p_state != Qt::PartiallyChecked)
+    {
+        CSettingsManager::GetInstance()->SetSetting(CSettingsManager::ST_UseControllerInput, (p_state == Qt::Checked));
+
+        std::string l_message("useControllerInput ");
         l_message.append(std::to_string((p_state == Qt::Checked) ? 1 : 0));
         CVRManager::GetInstance()->SendStationMessage(l_message);
     }

--- a/leap_control/Ui/leap_control.h
+++ b/leap_control/Ui/leap_control.h
@@ -17,6 +17,7 @@ private:
     void OnTrackingLevelChange(int p_item);
     void OnHandsResetChange(int p_state);
     void OnUseVelocityChange(int p_state);
+    void OnUseControllerInputChange(int p_state);
 
     void OnStartMinimizedChanged(int p_state);
 

--- a/leap_control/Ui/leap_control.ui
+++ b/leap_control/Ui/leap_control.ui
@@ -758,10 +758,145 @@ QCheckBox::indicator:unchecked:hover
       </property>
      </widget>
     </widget>
+    <widget class="QFrame" name="frame_15">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>210</y>
+       <width>600</width>
+       <height>40</height>
+      </rect>
+     </property>
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <italic>false</italic>
+       <bold>false</bold>
+       <underline>false</underline>
+       <strikeout>false</strikeout>
+       <kerning>true</kerning>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(10, 14, 19);
+border-radius: 10px;</string>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <widget class="QLabel" name="label_21">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>300</width>
+        <height>40</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>-1</pointsize>
+        <weight>50</weight>
+        <italic>false</italic>
+        <bold>false</bold>
+       </font>
+      </property>
+      <property name="toolTip">
+       <string>If enabled, use tray icon to show this window</string>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QLabel
+{
+	color: rgb(255, 255, 255);
+	font-size: 16px;
+}
+QToolTip
+{
+	background-color:  rgb(14, 20, 27);
+	border: 1px solid #23262e;
+	border-radius: 2px;
+	color: white;
+	font: 14px;
+}</string>
+      </property>
+      <property name="lineWidth">
+       <number>0</number>
+      </property>
+      <property name="text">
+       <string>Use game controller</string>
+      </property>
+      <property name="textFormat">
+       <enum>Qt::AutoText</enum>
+      </property>
+      <property name="scaledContents">
+       <bool>false</bool>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+      <property name="margin">
+       <number>0</number>
+      </property>
+      <property name="indent">
+       <number>0</number>
+      </property>
+      <property name="textInteractionFlags">
+       <set>Qt::NoTextInteraction</set>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="m_useControllerInputCheckBox">
+      <property name="geometry">
+       <rect>
+        <x>432</x>
+        <y>4</y>
+        <width>32</width>
+        <height>32</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::LeftToRight</enum>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QCheckBox::indicator
+{
+    background-color: #23262e;
+	border-radius: 4px;
+    width: 32px;
+    height: 32px;
+}
+
+QCheckBox::indicator:checked
+{
+    background-color: #ffffff;
+	border: 4px solid #3d4450;
+    width: 24px;
+   	height: 24px;
+}
+
+QCheckBox::indicator:unchecked:hover
+{
+	background-color: #3d4450;
+}</string>
+      </property>
+      <property name="text">
+       <string>CheckBox</string>
+      </property>
+     </widget>
+    </widget>
     <zorder>frame_2</zorder>
     <zorder>frame_3</zorder>
     <zorder>frame</zorder>
     <zorder>frame_9</zorder>
+    <zorder>frame_15</zorder>
    </widget>
    <widget class="QWidget" name="tab_2">
     <attribute name="title">

--- a/vendor/JSL
+++ b/vendor/JSL
@@ -1,0 +1,1 @@
+https://github.com/JibbSmart/JoyShockLibrary/releases/tag/v3.0


### PR DESCRIPTION
This PR implements support for game controllers so they can be used for input instead of the overlay application, for now the implementation contains support for:

- Nintendo Joycon(s)
- DualShock 4

But other can be added in future, with minimal effort, one thing to note is that gesture inputs are disabled when you enable game controller input.