### PR TITLE
Fixing thumb rotation, applying joint positions for proper hand scaling

### DIFF
--- a/driver_leap/Devices/Controller/CLeapIndexController.cpp
+++ b/driver_leap/Devices/Controller/CLeapIndexController.cpp
@@ -16,7 +16,7 @@ const glm::mat4 g_wristOffsetLeft = glm::inverse(glm::translate(g_identityMatrix
 const glm::mat4 g_wristOffsetRight = glm::inverse(glm::translate(g_identityMatrix, glm::vec3(0.0445230342f, 0.0301547553f, 0.16438961f)) * glm::toMat4(glm::quat(1.50656376e-07f, -1.77612698e-08f, -0.927827835f, 0.373008907f)));
 const glm::quat g_skeletonOffsetLeft = glm::quat(glm::vec3(g_pi, 0.f, g_piHalf));
 const glm::quat g_skeletonOffsetRight = glm::quat(glm::vec3(g_pi, 0.f, -g_piHalf));
-const glm::quat g_thumbOffset = glm::quat(glm::vec3(-g_piHalf * 0.5, 0.f, 0.f)) * glm::quat(glm::vec3(-g_piHalf, g_piHalf, -g_piHalf));
+const glm::quat g_thumbOffset = glm::quat(glm::vec3(-g_piHalf * 0.5, 0.f, 0.f)) * glm::quat(glm::vec3(-g_piHalf, g_piHalf, -g_piHalf)); // glm::quat(1, 0, 0, 0);
 const glm::quat g_metacarpalOffset = glm::quat(glm::vec3(-g_piHalf, g_piHalf, 0.f));
 const glm::quat g_mirroringOffset = glm::quat(glm::vec3(g_pi, 0.f, 0.f));
 
@@ -454,17 +454,46 @@ void CLeapIndexController::UpdateSkeletalInput(const CLeapHand *p_hand)
     for(size_t i = 0U; i < 5U; i++)
     {
         size_t l_indexFinger = GetFingerBoneIndex(i);
-        for(size_t j = 0U; j < ((i == 0U) ? 3U : 4U); j++)
-        {
-            glm::quat l_rot;
-            p_hand->GetFingerBoneLocalRotation(i, (i == 0U) ? (j + 1U) : j, l_rot);
-            ChangeBoneOrientation(l_rot);
 
-            if(j == 0U)
-                FixMetacarpalBone(l_rot, i == 0);
+		if (i == 0U)
+		{
+			for (size_t j = 0U; j < 3U; j++)
+			{
+				glm::quat l_rot;
+				glm::vec3 l_pos;
 
-            ConvertQuaternion(l_rot, m_boneTransform[l_indexFinger + j].orientation);
-        }
+				p_hand->GetThumbBoneLocalRotation(i, j + 1U, l_rot);
+				p_hand->GetFingerBoneLocalPosition(i, j + 1U, l_pos);
+
+				ChangeBoneOrientation(l_rot);
+				if (j == 0U) FixMetacarpalBone(l_rot, false);
+				ChangeBonePosition(l_pos);
+
+				ConvertQuaternion(l_rot, m_boneTransform[l_indexFinger + j].orientation);
+				if(j > 0U) ConvertVector3(l_pos, m_boneTransform[l_indexFinger + j].position);
+			}
+		}
+		else
+		{
+			for (size_t j = 0U; j < 4U; j++)
+			{
+				glm::quat l_rot;
+				glm::vec3 l_pos;
+
+				p_hand->GetFingerBoneLocalRotation(i, j, l_rot);
+				p_hand->GetFingerBoneLocalPosition(i, j, l_pos);
+
+				ChangeBoneOrientation(l_rot);
+				if (j == 0U)
+				{
+					FixMetacarpalBone(l_rot, i == 0);
+				}
+				ChangeBonePosition(l_pos);
+
+				ConvertQuaternion(l_rot, m_boneTransform[l_indexFinger + j].orientation);
+				if(j > 0U) ConvertVector3(l_pos, m_boneTransform[l_indexFinger + j].position);
+			}
+		}
     }
 
     // Update aux bones
@@ -516,6 +545,18 @@ void CLeapIndexController::ChangeBoneOrientation(glm::quat &p_rot) const
         p_rot.x *= -1.f;
         p_rot.y *= -1.f;
     }
+}
+
+void CLeapIndexController::ChangeBonePosition(glm::vec3 &p_pos) const
+{
+	std::swap(p_pos.x, p_pos.z);
+	p_pos.z *= -1.f;
+
+	if (m_isLeft)
+	{
+		p_pos.x *= -1.f;
+		p_pos.y *= 1.f;
+	}
 }
 
 void CLeapIndexController::FixMetacarpalBone(glm::quat & p_rot, bool p_thumb) const

--- a/driver_leap/Devices/Controller/CLeapIndexController.h
+++ b/driver_leap/Devices/Controller/CLeapIndexController.h
@@ -75,6 +75,7 @@ class CLeapIndexController : public vr::ITrackedDeviceServerDriver
 
     void ResetControls();
     void ChangeBoneOrientation(glm::quat &p_rot) const;
+	void ChangeBonePosition(glm::vec3 &p_pos) const;
     void FixMetacarpalBone(glm::quat &p_rot, bool p_thumb) const;
 
     void ProcessExternalInput(const char *p_message);

--- a/driver_leap/Leap/CLeapHand.cpp
+++ b/driver_leap/Leap/CLeapHand.cpp
@@ -71,7 +71,16 @@ void CLeapHand::GetFingerBoneLocalPosition(size_t p_finger, size_t p_bone, glm::
     l_result = l_childLocal * g_pointVec4;
 }
 
-void CLeapHand::GetFingerBoneLocalRotation(size_t p_finger, size_t p_bone, glm::quat & l_result) const
+void CLeapHand::GetThumbBoneLocalRotation(size_t p_finger, size_t p_bone, glm::quat &l_result) const
+{
+	if ((p_finger != 0u) || (p_bone >= 4U))
+		return;
+
+	size_t l_index = p_finger * 4U + p_bone;
+	l_result = glm::inverse((p_bone == 1U) ? m_rotation : m_bonesRotations[l_index - 1U]) * m_bonesRotations[l_index];
+}
+
+void CLeapHand::GetFingerBoneLocalRotation(size_t p_finger, size_t p_bone, glm::quat &l_result) const
 {
     if((p_finger >= 5U) || (p_bone >= 4U))
         return;

--- a/driver_leap/Leap/CLeapHand.h
+++ b/driver_leap/Leap/CLeapHand.h
@@ -42,6 +42,7 @@ public:
 
     void GetFingerBoneLocalPosition(size_t p_finger, size_t p_bone, glm::vec3 &l_result) const;
     void GetFingerBoneLocalRotation(size_t p_finger, size_t p_bone, glm::quat &l_result) const;
+	void GetThumbBoneLocalRotation(size_t p_finger, size_t p_bone, glm::quat &l_result) const;
 
     float GetFingerBend(size_t p_finger) const;
     float GetGrabValue() const;


### PR DESCRIPTION
This pull request increases the accuracy of the SteamVR Skeletal Input Data, making it more representative of the data coming out of the Leap Motion device.

For comparison, I used an application built for this purpose. The grey and opaque low poly hands are a standard representation of Leap tracking data as provided by Ultraleap's unity plugin. The translucent hands are SteamVR hands.

### Before
https://github.com/SDraw/driver_leap/assets/4423326/15b53255-b69f-4f6a-b7a1-b503c84f78b0

### After
https://github.com/SDraw/driver_leap/assets/4423326/42bafd28-2287-4c4f-a53e-ac0bba9644da

This change enables applications that natively support hand tracking via SteamVR Skeletal Input to rely on the incoming tracking data for input purposes. The video demonstrates that pinch gestures are now enabled, as are fingertip positions for poking. It also brings this driver one step closer to being conformant with VRChat's [SteamVR Skeletal Hand Tracking Driver Guide](https://creators.vrchat.com/platforms/pc/steamvr-drivers/)

